### PR TITLE
[WIP] Administration tool

### DIFF
--- a/admin.ml
+++ b/admin.ml
@@ -1,0 +1,63 @@
+open Containers
+open Lwt.Infix
+
+let admin_action ~logdir user body =
+  match String.split_on_char '\n' body with
+  | "check"::dir::dockerfile ->
+      let dockerfile = String.concat "\n" dockerfile in
+      Lwt.ignore_result begin
+        Check.get_pkgs ~dockerfile >>= fun (img_name, pkgs) ->
+        Check.get_jobs ~img_name ~logdir pkgs
+      end
+  | _ ->
+      assert false (* TODO *)
+
+let is_bzero = function
+  | '\000' -> true
+  | _ -> false
+
+(* TODO: https://github.com/c-cube/ocaml-containers/pull/214 *)
+let ltrim s =
+  let i = ref 0 in
+  while !i < String.length s && is_bzero (String.unsafe_get s !i) do incr i done;
+  if !i > 0 then String.sub s !i (String.length s - !i) else s
+
+let is_username_char = function
+  | 'a'..'z' -> true
+  | '-' | '_' -> true
+  | _ -> false
+
+let get_user_key ~keysdir user =
+  if not (String.is_empty user) && String.for_all is_username_char user then
+    Lwt_io.with_file ~mode:Lwt_io.Input (Filename.concat keysdir user) Lwt_io.read >|= fun key ->
+    X509.Encoding.Pem.Private_key.of_pem_cstruct1 (Cstruct.of_string key)
+  else
+    Lwt.fail_with "Invalid username"
+
+let rec decrypt key msg =
+  let key_size = Nocrypto.Rsa.priv_bits key / 8 in
+  if String.length msg <= key_size then
+    ltrim (Cstruct.to_string (Nocrypto.Rsa.decrypt ~key (Cstruct.of_string msg)))
+  else
+    let msg, next = String.take_drop key_size msg in
+    decrypt key msg ^ decrypt key next
+
+let callback ~logdir ~keysdir conn req body =
+  Cohttp_lwt.Body.to_string body >>= fun body ->
+  match String.Split.left ~by:"\n" body with
+  | Some (user, "") ->
+      Lwt.fail_with "Empty message"
+  | Some (user, body) ->
+      get_user_key ~keysdir user >>= fun (`RSA key) ->
+      let body = decrypt key body in
+      begin match String.Split.left ~by:"\n" body with
+      | Some (user', body) when String.equal user user' ->
+          admin_action ~logdir user body;
+          Cohttp_lwt_unix.Server.respond ~status:`OK ~body:`Empty ()
+      | Some (user', _) ->
+          Lwt.fail_with "Identity couldn't be ensured"
+      | None ->
+          Lwt.fail_with "Identity check required"
+      end
+  | None ->
+      Lwt.fail_with "Cannot find username"

--- a/admin.ml
+++ b/admin.ml
@@ -5,7 +5,7 @@ let admin_action ~logdir user body =
   match String.split_on_char '\n' body with
   | "check"::dir::dockerfile ->
       let dockerfile = String.concat "\n" dockerfile in
-      Lwt.ignore_result (Check.check ~logdir ~dockerfile dir)
+      Check.check ~logdir ~dockerfile dir
   | _ ->
       assert false (* TODO *)
 
@@ -52,7 +52,7 @@ let callback ~logdir ~keysdir conn req body =
       let body = decrypt key body in
       begin match String.Split.left ~by:"\n" body with
       | Some (user', body) when String.equal user user' ->
-          admin_action ~logdir user body;
+          admin_action ~logdir user body >>= fun () ->
           Cohttp_lwt_unix.Server.respond ~status:`OK ~body:`Empty ()
       | Some (user', _) ->
           Lwt.fail_with "Identity couldn't be ensured"

--- a/admin.ml
+++ b/admin.ml
@@ -5,10 +5,7 @@ let admin_action ~logdir user body =
   match String.split_on_char '\n' body with
   | "check"::dir::dockerfile ->
       let dockerfile = String.concat "\n" dockerfile in
-      Lwt.ignore_result begin
-        Check.get_pkgs ~dockerfile >>= fun (img_name, pkgs) ->
-        Check.get_jobs ~img_name ~logdir pkgs
-      end
+      Lwt.ignore_result (Check.check ~logdir ~dockerfile dir)
   | _ ->
       assert false (* TODO *)
 

--- a/admin.mli
+++ b/admin.mli
@@ -1,0 +1,7 @@
+val callback :
+  logdir:string ->
+  keysdir:string ->
+  Cohttp_lwt_unix.Server.conn ->
+  Cohttp.Request.t ->
+  Cohttp_lwt.Body.t ->
+  (Cohttp.Response.t * Cohttp_lwt.Body.t) Lwt.t

--- a/cache.ml
+++ b/cache.ml
@@ -1,0 +1,27 @@
+open Containers
+
+module Hashtbl = Hashtbl.Make (struct
+    type t = Diff.comp list
+    let hash = Hashtbl.hash
+    let equal = List.equal Diff.comp_equal
+  end)
+
+(* TODO: Also cache pkgs ? *)
+let hashtbl = Hashtbl.create 32
+
+let clear () =
+  Hashtbl.clear hashtbl
+
+let get_html ~logdir compilers =
+  let is_default = List.is_empty compilers in
+  let compilers = if is_default then Diff.get_dirs logdir else compilers in
+  let pkgs = Diff.get_pkgs ~logdir compilers in
+  let html = Diff.get_html compilers pkgs in
+  Hashtbl.add hashtbl compilers html;
+  if is_default then Hashtbl.add hashtbl [] html;
+  html
+
+let get_html ~logdir compilers =
+  match Hashtbl.find_opt hashtbl compilers with
+  | Some html -> html
+  | None -> get_html ~logdir compilers

--- a/cache.mli
+++ b/cache.mli
@@ -1,3 +1,3 @@
 val clear : unit -> unit
 
-val get_html : logdir:string -> Diff.comp list -> string
+val get_html : logdir:string -> Diff.comp list -> string Lwt.t

--- a/cache.mli
+++ b/cache.mli
@@ -1,0 +1,3 @@
+val clear : unit -> unit
+
+val get_html : logdir:string -> Diff.comp list -> string

--- a/check.ml
+++ b/check.ml
@@ -2,7 +2,9 @@ open Containers
 open Lwt.Infix
 
 let write_line_unix fd s =
-  Lwt_io.write_line (Lwt_io.of_fd ~mode:Lwt_io.Output fd) s
+  let fd = Lwt_io.of_fd ~mode:Lwt_io.Output fd in
+  Lwt_io.write_line fd s >>= fun () ->
+  Lwt_io.flush fd
 
 let mkdir_p dir =
   let rec aux base = function

--- a/check.ml
+++ b/check.ml
@@ -1,4 +1,8 @@
+open Containers
 open Lwt.Infix
+
+type img = string
+type pkgs = string list
 
 let pool = Lwt_pool.create 32 (fun () -> Lwt.return_unit)
 
@@ -28,55 +32,42 @@ let docker_run ~stdout img cmd =
   let stdout = `FD_copy stdout in
   exec_in ~stdin:`Keep ~stdout ~stderr ("docker"::"run"::"--rm"::img::cmd)
 
-let get_pkgs ~logdir dockerfile =
-  Lwt_io.with_file ~mode:Lwt_io.Input dockerfile begin fun dockerfile ->
-    Lwt_io.read dockerfile >>= fun dockerfile ->
-    let md5 = Digest.to_hex (Digest.string dockerfile) in
-    let img_name = "opam-check-all-" ^ md5 in
-    docker_build ["-t"; img_name] dockerfile >>= fun _ ->
-    Lwt_io.write_line Lwt_io.stdout "Getting packages list..." >>= fun () ->
-    Lwt_process.pread ("", [|"docker"; "run"; img_name|]) >|= fun pkgs ->
-    (img_name, String.split_on_char '\n' pkgs)
-  end
+let get_pkgs ~dockerfile =
+  let md5 = Digest.to_hex (Digest.string dockerfile) in
+  let img_name = "opam-check-all-" ^ md5 in
+  docker_build ["-t"; img_name] dockerfile >>= fun _ ->
+  Lwt_io.write_line Lwt_io.stdout "Getting packages list..." >>= fun () ->
+  Lwt_process.pread ("", [|"docker"; "run"; img_name|]) >|= fun pkgs ->
+  (img_name, String.split_on_char '\n' pkgs)
 
-let rec get_jobs ~img_name ~logdir ~gooddir ~baddir jobs = function
+(* TODO: Redirect everything to a per user & jobs log *)
+let rec get_jobs ~img_name ~logdir ~gooddir ~baddir = function
   | [] ->
-      Lwt.return jobs
+      Lwt.return_unit
   | pkg::pkgs ->
-      let job =
-        Lwt_pool.use pool begin fun () ->
-          let goodlog = Filename.concat gooddir pkg in
-          let badlog = Filename.concat baddir pkg in
-          Lwt_unix.file_exists goodlog >>= fun goodlog_exists ->
-          Lwt_unix.file_exists badlog >>= fun badlog_exists ->
-          if goodlog_exists || badlog_exists then begin
-            Lwt_io.write_line Lwt_io.stdout (pkg^" has already been checked. Skipping...")
-          end else begin
-            Lwt_io.write_line Lwt_io.stdout ("Checking "^pkg^"...") >>= fun () ->
-            let logfile = Filename.concat logdir pkg in
-            Lwt_unix.openfile logfile [Unix.O_WRONLY; Unix.O_CREAT; Unix.O_TRUNC] 0o640 >>= fun stdout ->
-            let stdout = Lwt_unix.unix_file_descr stdout in
-            docker_run ~stdout img_name ["opam";"depext";"-ivy";pkg] >>= begin function
-            | Ok () -> Lwt_unix.rename logfile goodlog
-            | Error () -> Lwt_unix.rename logfile badlog
-            end
+      Lwt_pool.use pool begin fun () ->
+        let goodlog = Filename.concat gooddir pkg in
+        let badlog = Filename.concat baddir pkg in
+        Lwt_unix.file_exists goodlog >>= fun goodlog_exists ->
+        Lwt_unix.file_exists badlog >>= fun badlog_exists ->
+        if goodlog_exists || badlog_exists then begin
+          Lwt_io.write_line Lwt_io.stdout (pkg^" has already been checked. Skipping...")
+        end else begin
+          Lwt_io.write_line Lwt_io.stdout ("Checking "^pkg^"...") >>= fun () ->
+          let logfile = Filename.concat logdir pkg in
+          Lwt_unix.openfile logfile [Unix.O_WRONLY; Unix.O_CREAT; Unix.O_TRUNC] 0o640 >>= fun stdout ->
+          let stdout = Lwt_unix.unix_file_descr stdout in
+          docker_run ~stdout img_name ["opam";"depext";"-ivy";pkg] >>= begin function
+          | Ok () -> Lwt_unix.rename logfile goodlog
+          | Error () -> Lwt_unix.rename logfile badlog
           end
         end
-      in
-      get_jobs ~img_name ~logdir ~gooddir ~baddir (job :: jobs) pkgs
+      end |> Lwt.ignore_result;
+      get_jobs ~img_name ~logdir ~gooddir ~baddir pkgs
 
-let () =
-  match Sys.argv with
-  | [|_; logdir; dockerfile|] ->
-      let gooddir = Filename.concat logdir "good" in
-      let baddir = Filename.concat logdir "bad" in
-      Lwt_main.run begin
-        Lwt_process.exec ("", [|"mkdir"; "-p"; gooddir|]) >>= fun _ ->
-        Lwt_process.exec ("", [|"mkdir"; "-p"; baddir|]) >>= fun _ ->
-        get_pkgs ~logdir dockerfile >>= fun (img_name, pkgs) ->
-        get_jobs ~img_name ~logdir ~gooddir ~baddir [] pkgs >>=
-        Lwt.join
-      end
-  | _ ->
-      prerr_endline "Read the code and try again";
-      exit 1
+let get_jobs ~img_name ~logdir pkgs =
+  let gooddir = Filename.concat logdir "good" in
+  let baddir = Filename.concat logdir "bad" in
+  Lwt_process.exec ("", [|"mkdir"; "-p"; gooddir|]) >>= fun _ ->
+  Lwt_process.exec ("", [|"mkdir"; "-p"; baddir|]) >>= fun _ ->
+  get_jobs ~img_name ~logdir ~gooddir ~baddir pkgs

--- a/check.ml
+++ b/check.ml
@@ -43,7 +43,10 @@ let get_pkgs ~dockerfile =
 (* TODO: Redirect everything to a per user & jobs log *)
 let rec get_jobs ~img_name ~logdir ~gooddir ~baddir = function
   | [] ->
-      Lwt.return_unit
+      Lwt_pool.use pool begin fun () ->
+        Cache.clear ();
+        Lwt.return_unit
+      end
   | pkg::pkgs ->
       Lwt_pool.use pool begin fun () ->
         let goodlog = Filename.concat gooddir pkg in

--- a/check.ml
+++ b/check.ml
@@ -12,7 +12,12 @@ let mkdir_p dir =
         Lwt.return_unit
     | x::xs ->
         let dir = Filename.concat base x in
-        Lwt_unix.mkdir dir 0o750 >>= fun () ->
+        Lwt.catch begin fun () ->
+          Lwt_unix.mkdir dir 0o750
+        end begin function
+        | Unix.Unix_error (Unix.EEXIST, _, _) -> Lwt.return_unit
+        | e -> Lwt.fail e
+        end >>= fun () ->
         aux dir xs
   in
   match String.Split.list_cpy ~by:Filename.dir_sep dir with

--- a/check.ml
+++ b/check.ml
@@ -23,7 +23,7 @@ let proc_fd_of_unix = function
   | `Close -> `Close
   | `Dev_null -> `Dev_null
   | `FD_move fd -> `FD_move (Lwt_unix.unix_file_descr fd)
-  | `FD_copy fd -> `FD_move (Lwt_unix.unix_file_descr fd)
+  | `FD_copy fd -> `FD_copy (Lwt_unix.unix_file_descr fd)
   | `Keep -> `Keep
 
 exception Process_failure

--- a/check.ml
+++ b/check.ml
@@ -121,6 +121,7 @@ let async_proc ~stderr f =
 
 let check ~logdir ~dockerfile name =
   let logfile = Filename.concat logdir (name^".log") in
+  let logdir = Filename.concat logdir name in
   Lwt_unix.openfile logfile [Unix.O_WRONLY; Unix.O_CREAT; Unix.O_TRUNC] 0o640 >>= fun stderr ->
   Lwt.catch begin fun () ->
     let gooddir = Filename.concat logdir "good" in

--- a/check.ml
+++ b/check.ml
@@ -1,9 +1,6 @@
 open Containers
 open Lwt.Infix
 
-type img = string
-type pkgs = string list
-
 let write_line_unix fd s =
   Lwt_io.write_line (Lwt_io.of_fd ~mode:Lwt_io.Output fd) s
 
@@ -22,73 +19,97 @@ let mkdir_p dir =
 
 let pool = Lwt_pool.create 32 (fun () -> Lwt.return_unit)
 
-let exec_in ~stdin ~stdout ~stderr cmd =
+let proc_fd_of_unix = function
+  | `Close -> `Close
+  | `Dev_null -> `Dev_null
+  | `FD_move fd -> `FD_move (Lwt_unix.unix_file_descr fd)
+  | `FD_copy fd -> `FD_move (Lwt_unix.unix_file_descr fd)
+  | `Keep -> `Keep
+
+exception Process_failure
+
+let exec ~stdin ~stdout ~stderr cmd =
+  let stdin = proc_fd_of_unix stdin in
+  let stdout = proc_fd_of_unix (`FD_copy stdout) in
+  let stderr_lwt = stderr in
+  let stderr = proc_fd_of_unix (`FD_copy stderr) in
   Lwt_process.exec ~stdin ~stdout ~stderr ("", Array.of_list cmd) >>= function
   | Unix.WEXITED 0 ->
-      Lwt.return (Ok ())
+      Lwt.return_unit
   | _ ->
       let cmd = String.concat " " cmd in
-      Lwt_io.write_line Lwt_io.stderr ("Command '"^cmd^"' failed.") >>= fun () ->
-      Lwt.return (Error ())
+      write_line_unix stderr_lwt ("Command '"^cmd^"' failed.") >>= fun () ->
+      Lwt.fail Process_failure
 
-let docker_build ~stdout args dockerfile =
-  let stdout = Lwt_unix.unix_file_descr stdout in
-  let stdin, fd = Lwt_unix.pipe_out () in
+let docker_build ~stderr ~img_name dockerfile =
+  let stdin, fd = Lwt_unix.pipe () in
   let stdin = `FD_move stdin in
-  let stderr = `FD_copy stdout in
-  let stdout = `FD_copy stdout in
-  let fd = Lwt_io.of_fd ~mode:Lwt_io.Output fd in
-  Lwt_io.write_line fd dockerfile >>= fun () ->
-  Lwt_io.close fd >>= fun () ->
-  exec_in ~stdin ~stdout ~stderr ("docker"::"build"::args@["-"])
+  write_line_unix fd dockerfile >>= fun () ->
+  Lwt_unix.close fd >>= fun () ->
+  exec ~stdin ~stdout:stderr ~stderr ["docker";"build";"-t";img_name;"-"]
 
-let docker_run ~stdout img cmd =
-  let stdout = Lwt_unix.unix_file_descr stdout in
-  let stderr = `FD_move stdout in
-  let stdout = `FD_copy stdout in
-  exec_in ~stdin:`Close ~stdout ~stderr ("docker"::"run"::"--rm"::img::cmd)
+let docker_run ~stdout ~stderr img cmd =
+  exec ~stdin:`Close ~stdout ~stderr ("docker"::"run"::"--rm"::img::cmd)
 
-let get_pkgs ~stdout ~dockerfile =
+let get_pkgs ~stderr ~dockerfile =
   let md5 = Digest.to_hex (Digest.string dockerfile) in
   let img_name = "opam-check-all-" ^ md5 in
-  docker_build ~stdout ["-t"; img_name] dockerfile >>= fun _ ->
-  write_line_unix stdout "Getting packages list..." >>= fun () ->
-  Lwt_process.pread ("", [|"docker"; "run"; img_name|]) >|= fun pkgs ->
+  docker_build ~stderr ~img_name dockerfile >>= fun () ->
+  let fd, stdout = Lwt_unix.pipe () in
+  write_line_unix stderr "Getting packages list..." >>= fun () ->
+  docker_run ~stdout ~stderr img_name [] >>= fun () ->
+  Lwt_unix.close stdout >>= fun () ->
+  Lwt_io.read (Lwt_io.of_fd ~mode:Lwt_io.Input fd) >>= fun pkgs ->
+  Lwt_unix.close fd >|= fun () ->
   (img_name, String.split_on_char '\n' pkgs)
 
-(* TODO: Redirect everything to a per user & jobs log *)
-let rec get_jobs ~stdout ~img_name ~logdir ~gooddir ~baddir = function
+let rec get_jobs ~stderr ~img_name ~logdir ~gooddir ~baddir jobs = function
   | [] ->
       Lwt_pool.use pool begin fun () ->
+        Lwt.join jobs >>= fun () ->
         Cache.clear ();
-        Lwt_unix.close stdout
+        Lwt_unix.close stderr
       end
   | pkg::pkgs ->
-      Lwt_pool.use pool begin fun () ->
-        let goodlog = Filename.concat gooddir pkg in
-        let badlog = Filename.concat baddir pkg in
-        Lwt_unix.file_exists goodlog >>= fun goodlog_exists ->
-        Lwt_unix.file_exists badlog >>= fun badlog_exists ->
-        if goodlog_exists || badlog_exists then begin
-          write_line_unix stdout (pkg^" has already been checked. Skipping...")
-        end else begin
-          write_line_unix stdout ("Checking "^pkg^"...") >>= fun () ->
-          let logfile = Filename.concat logdir pkg in
-          Lwt_unix.openfile logfile [Unix.O_WRONLY; Unix.O_CREAT; Unix.O_TRUNC] 0o640 >>= fun stdout ->
-          docker_run ~stdout img_name ["opam";"depext";"-ivy";pkg] >>= begin function
-          | Ok () -> Lwt_unix.rename logfile goodlog
-          | Error () -> Lwt_unix.rename logfile badlog
+      let job =
+        Lwt_pool.use pool begin fun () ->
+          let goodlog = Filename.concat gooddir pkg in
+          let badlog = Filename.concat baddir pkg in
+          Lwt_unix.file_exists goodlog >>= fun goodlog_exists ->
+          Lwt_unix.file_exists badlog >>= fun badlog_exists ->
+          if goodlog_exists || badlog_exists then begin
+            write_line_unix stderr (pkg^" has already been checked. Skipping...")
+          end else begin
+            write_line_unix stderr ("Checking "^pkg^"...") >>= fun () ->
+            let logfile = Filename.concat logdir pkg in
+            Lwt_unix.openfile logfile [Unix.O_WRONLY; Unix.O_CREAT; Unix.O_TRUNC] 0o640 >>= fun stdout ->
+            Lwt.finalize begin fun () ->
+              Lwt.catch begin fun () ->
+                docker_run ~stdout ~stderr:stdout img_name ["opam";"depext";"-ivy";pkg] >>= fun () ->
+                Lwt_unix.rename logfile goodlog
+              end begin function
+              | Process_failure -> Lwt_unix.rename logfile badlog
+              | e -> Lwt.fail e
+              end
+            end begin fun () ->
+              Lwt_unix.close stdout
+            end
           end
         end
-      end |> Lwt.ignore_result;
-      get_jobs ~stdout ~img_name ~logdir ~gooddir ~baddir pkgs
+      in
+      get_jobs ~stderr ~img_name ~logdir ~gooddir ~baddir (job :: jobs) pkgs
 
 let check ~logdir ~dockerfile name =
   let logfile = Filename.concat logdir (name^".log") in
-  Lwt_unix.openfile logfile [Unix.O_WRONLY; Unix.O_CREAT; Unix.O_TRUNC] 0o640 >>= fun stdout ->
-  get_pkgs ~stdout ~dockerfile >>= fun (img_name, pkgs) ->
-  let gooddir = Filename.concat logdir "good" in
-  let baddir = Filename.concat logdir "bad" in
-  mkdir_p gooddir >>= fun () ->
-  mkdir_p baddir >>= fun () ->
-  get_jobs ~stdout ~img_name ~logdir ~gooddir ~baddir pkgs
+  Lwt_unix.openfile logfile [Unix.O_WRONLY; Unix.O_CREAT; Unix.O_TRUNC] 0o640 >>= fun stderr ->
+  Lwt.catch begin fun () ->
+    get_pkgs ~stderr ~dockerfile >>= fun (img_name, pkgs) ->
+    let gooddir = Filename.concat logdir "good" in
+    let baddir = Filename.concat logdir "bad" in
+    mkdir_p gooddir >>= fun () ->
+    mkdir_p baddir >>= fun () ->
+    get_jobs ~stderr ~img_name ~logdir ~gooddir ~baddir [] pkgs
+  end begin fun e ->
+    Lwt_unix.close stderr >>= fun () ->
+    Lwt.fail e
+  end

--- a/check.mli
+++ b/check.mli
@@ -1,6 +1,1 @@
-type img
-type pkgs
-
-val get_pkgs : dockerfile:string -> (img * pkgs) Lwt.t
-
-val get_jobs : img_name:img -> logdir:string -> pkgs -> unit Lwt.t
+val check : logdir:string -> dockerfile:string -> string -> unit Lwt.t

--- a/check.mli
+++ b/check.mli
@@ -1,0 +1,6 @@
+type img
+type pkgs
+
+val get_pkgs : dockerfile:string -> (img * pkgs) Lwt.t
+
+val get_jobs : img_name:img -> logdir:string -> pkgs -> unit Lwt.t

--- a/client.ml
+++ b/client.ml
@@ -1,0 +1,37 @@
+open Containers
+
+let parse_key key =
+  let key = IO.with_in key IO.read_all in
+  let `RSA key = X509.Encoding.Pem.Private_key.of_pem_cstruct1 (Cstruct.of_string key) in
+  Nocrypto.Rsa.pub_of_priv key
+
+let rec encrypt_msg ~key msg =
+  let max_size = Nocrypto.Rsa.pub_bits key / 8 in
+  if String.length msg <= max_size then
+    Cstruct.to_string (Nocrypto.Rsa.encrypt ~key (Cstruct.of_string msg))
+  else
+    let msg, next = String.take_drop max_size msg in
+    encrypt_msg ~key msg ^ encrypt_msg ~key next
+
+let send_msg ~key ~username ~hostname msg =
+  let key = parse_key key in
+  let prefix = username^"\n" in
+  let msg = encrypt_msg ~key (prefix^msg) in
+  let uri = Uri.make ~scheme:"http" ~host:hostname ~port:9999 () in
+  Lwt_main.run (Cohttp_lwt_unix.Client.post ~body:(`String (prefix^msg)) uri)
+
+(* TODO: Have a config file to store repetitive informations *)
+let () =
+  match Sys.argv with
+  | [|_; key; username; hostname; comp; dockerfile|] ->
+      print_endline "Sending command...";
+      let dockerfile = IO.with_in dockerfile IO.read_all in
+      let msg = "check\n"^comp^"\n"^dockerfile in
+      let res, body = send_msg ~key ~username ~hostname msg in
+      begin match Cohttp.Response.status res with
+      | `OK -> print_endline "Command sent successfully"
+      | _ -> prerr_endline "A problem occured"; exit 1
+      end
+  | _ ->
+      prerr_endline "Read the code and try again";
+      exit 1

--- a/client.ml
+++ b/client.ml
@@ -5,13 +5,16 @@ let parse_key key =
   let `RSA key = X509.Encoding.Pem.Private_key.of_pem_cstruct1 (Cstruct.of_string key) in
   Nocrypto.Rsa.pub_of_priv key
 
+let partial_encrypt key msg =
+  Cstruct.to_string (Nocrypto.Rsa.encrypt ~key (Cstruct.of_string msg))
+
 let rec encrypt_msg ~key msg =
   let max_size = Nocrypto.Rsa.pub_bits key / 8 in
   if String.length msg <= max_size then
-    Cstruct.to_string (Nocrypto.Rsa.encrypt ~key (Cstruct.of_string msg))
+    partial_encrypt key msg
   else
     let msg, next = String.take_drop max_size msg in
-    encrypt_msg ~key msg ^ encrypt_msg ~key next
+    partial_encrypt key msg ^ encrypt_msg ~key next
 
 let send_msg ~key ~username ~hostname msg =
   let key = parse_key key in

--- a/diff.ml
+++ b/diff.ml
@@ -82,3 +82,4 @@ let get_html compilers pkgs =
   Format.sprintf "%a\n" (pp ()) doc
 
 let comp_from_string x = x
+let comp_equal = String.equal

--- a/diff.mli
+++ b/diff.mli
@@ -6,3 +6,4 @@ val get_pkgs : logdir:string -> comp list -> pkgs
 val get_html : comp list -> pkgs -> string
 
 val comp_from_string : string -> comp
+val comp_equal : comp -> comp -> bool

--- a/diff.mli
+++ b/diff.mli
@@ -1,8 +1,8 @@
 type comp
 type pkgs
 
-val get_dirs : string -> comp list
-val get_pkgs : logdir:string -> comp list -> pkgs
+val get_dirs : string -> comp list Lwt.t
+val get_pkgs : logdir:string -> comp list -> pkgs Lwt.t
 val get_html : comp list -> pkgs -> string
 
 val comp_from_string : string -> comp

--- a/jbuild
+++ b/jbuild
@@ -9,5 +9,5 @@
 (executable
   ((name server)
    (public_name opam-serve-all)
-   (modules (server diff admin check))
+   (modules (server diff admin check cache))
    (libraries (tyxml cohttp-lwt-unix containers opam-core x509))))

--- a/jbuild
+++ b/jbuild
@@ -1,13 +1,13 @@
 (jbuild_version 1)
 
 (executable
-  ((name check)
+  ((name client)
    (public_name opam-check-all)
-   (modules (check))
-   (libraries (lwt.unix))))
+   (modules (client))
+   (libraries (x509 cohttp-lwt-unix containers))))
 
 (executable
   ((name server)
    (public_name opam-serve-all)
-   (modules (server diff))
-   (libraries (tyxml cohttp-lwt-unix containers opam-core))))
+   (modules (server diff admin check))
+   (libraries (tyxml cohttp-lwt-unix containers opam-core x509))))

--- a/opam-check-all.opam
+++ b/opam-check-all.opam
@@ -14,4 +14,5 @@ depends: [
   "cohttp-lwt-unix"
   "containers"
   "opam-core"
+  "x509"
 ]

--- a/server.ml
+++ b/server.ml
@@ -13,7 +13,7 @@ end = struct
   let rec normalize_path = function
     | [] -> []
     | ""::xs -> normalize_path xs
-    | ".."::_ -> failwith "You bastard !"
+    | ".."::_ -> failwith "You bastard !" (* TODO: Use Filename.parent_dir *)
     | x::_ when String.mem ~sub:Filename.dir_sep x -> failwith "You bastard !!"
     | x::xs -> x :: normalize_path xs
 

--- a/server.ml
+++ b/server.ml
@@ -36,10 +36,12 @@ let serv_file ~content_type ~logdir file =
 let callback ~logdir _conn req _body =
   match Path.of_uri (Cohttp.Request.uri req) with
   | [] ->
-      serv_string ~content_type:"text/html" (Cache.get_html ~logdir [])
+      Cache.get_html ~logdir [] >>= fun html ->
+      serv_string ~content_type:"text/html" html
   | "diff"::compilers ->
       let compilers = List.map Diff.comp_from_string compilers in
-      serv_string ~content_type:"text/html" (Cache.get_html ~logdir compilers)
+      Cache.get_html ~logdir compilers >>= fun html ->
+      serv_string ~content_type:"text/html" html
   | path ->
       serv_file ~content_type:"text/plain" ~logdir (Path.to_string path)
 


### PR DESCRIPTION
This branch keeps track of the progress on making an administration tool for the opam-check-all server. This allows several users to do checks without having access to the server itself.
cc @samoht

Identification is for the moment done by having one RSA private key per users on both sides because the `x509` library doesn't support public key format given by `ssh-keygen`. The only format accepted is `PKCS8` and can be converted from the default format with the following command:
```
$ ssh-keygen -e -f key.pub -m PKCS8 > key-pkcs8.pub
```
I might use `Nocrypto`'s internal key format (sexp) at one point anyway and use two key pairs to also encrypt the whole connection (for the moment the username is prefixed in clear text to know which key to use for the rest of the message).
cc @hannesm