### PR TITLE
Some backports from opam-health-check-ng

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ slack-webhooks: []
 ## REST API
 
 opam-health-check-ng ships with a REST API that anyone can query:
-- `/api/v1/latest/packages` will return a JSON array of every package tested in the latest run.
+- `/api/v2/latest/packages` will return a JSON array of every package tested in the latest run.
   The expected result looks like:
   ```json
   [
@@ -117,7 +117,8 @@ opam-health-check-ng ships with a REST API that anyone can query:
       "statuses": [
         {
           "compiler": "<compiler name>",
-          "status": "<good|partial|bad|not-available|internal-failure>"
+          "status": "<good|partial|bad|not-available|internal-failure>",
+          "log": "</path/to/log>"
         },
         ...
       ]

--- a/README.md
+++ b/README.md
@@ -104,3 +104,24 @@ ocaml-switches:
 - "5.0+more_volatile": ocaml-variants.5.0.0+more_volatile
 slack-webhooks: []
 ```
+
+## REST API
+
+opam-health-check-ng ships with a REST API that anyone can query:
+- `/api/v1/latest/packages` will return a JSON array of every package tested in the latest run.
+  The expected result looks like:
+  ```json
+  [
+    {
+      "name": "<pkgname>.<version>",
+      "statuses": [
+        {
+          "compiler": "<compiler name>",
+          "status": "<good|partial|bad|not-available|internal-failure>"
+        },
+        ...
+      ]
+    },
+    ...
+  ]
+  ```

--- a/server/lib/cache.ml
+++ b/server/lib/cache.ml
@@ -164,6 +164,13 @@ let must_show_package ~logsearch query ~is_latest pkg =
       true
   end >>&& begin fun () ->
     Lwt.return @@
+    match snd query.Html.packages with
+    | Some re ->
+        Re.execp re (Pkg.name pkg) ||
+        Re.execp re (Pkg.full_name pkg)
+    | None -> true
+  end >>&& begin fun () ->
+    Lwt.return @@
     match snd query.Html.maintainers with
     | Some re -> List.exists (Re.execp re) opam.OpamFile.OPAM.maintainer
     | None -> true

--- a/server/lib/cache.ml
+++ b/server/lib/cache.ml
@@ -276,14 +276,18 @@ let get_html_run_list self =
   let+ pkgs = self.pkgs in
   Html.get_run_list (List.map fst pkgs)
 
-let get_json_latest_packages self =
+let get_json_latest_packages api_version self =
   let* self = !self in
   let* v = self.logdirs in
-  let+ pkgs = match v with
-    | [] -> Lwt.return []
+  let+ pkgs, logdir =
+    match v with
+    | [] -> Lwt.return ([], None)
     | logdir::_ ->
         let* pkgs = self.pkgs in
-        get_or_recompute (List.assoc ~eq:Server_workdirs.logdir_equal logdir pkgs)
+        let* pkgs = get_or_recompute (List.assoc ~eq:Server_workdirs.logdir_equal logdir pkgs) in
+        match api_version with
+        | `V1 -> Lwt.return (pkgs, None)
+        | `V2 -> Lwt.return (pkgs, Some logdir)
   in
-  let json = Json.pkgs_to_json pkgs in
+  let json = Json.pkgs_to_json ~logdir pkgs in
   Yojson.Safe.to_string json

--- a/server/lib/cache.mli
+++ b/server/lib/cache.mli
@@ -24,4 +24,4 @@ val get_revdeps : t -> string -> int Lwt.t
 val get_html_diff : conf:Server_configfile.t -> old_logdir:Server_workdirs.logdir -> new_logdir:Server_workdirs.logdir -> t -> string Lwt.t
 val get_html_diff_list : t -> string Lwt.t
 val get_html_run_list : t -> string Lwt.t
-val get_json_latest_packages : t -> string Lwt.t
+val get_json_latest_packages : [`V1 | `V2] -> t -> string Lwt.t

--- a/server/lib/html.ml
+++ b/server/lib/html.ml
@@ -18,6 +18,7 @@ type query = {
   show_diff_only : bool;
   show_latest_only : bool;
   sort_by_revdeps : bool;
+  packages : string * Re.re option;
   maintainers : string * Re.re option;
   logsearch : string * (Re.re * Compiler.t) option; (* TODO: Remove Re.re? (unused?) *)
 }
@@ -331,6 +332,8 @@ let get_html ~logdir ~conf query pkgs =
   let show_latest_only = input ~a:(a_input_type `Checkbox::a_name "show-latest-only"::a_value "true"::if query.show_latest_only then [a_checked ()] else []) () in
   let sort_by_revdeps_text = [txt "Sort by number of revdeps:"] in
   let sort_by_revdeps = input ~a:(a_input_type `Checkbox::a_name "sort-by-revdeps"::a_value "true"::if query.sort_by_revdeps then [a_checked ()] else []) () in
+  let packages_text = [txt "Only show packages whose name match [comma-separated glob]:"] in
+  let packages = input ~a:[a_input_type `Text; a_name "packages"; a_value (fst query.packages)] () in
   let maintainers_text = [txt "Only show packages maintained by [posix regexp]:"] in
   let maintainers = input ~a:[a_input_type `Text; a_name "maintainers"; a_value (fst query.maintainers)] () in
   let logsearch_text = [txt "Only show packages whose log matches [posix regexp]:"] in
@@ -350,6 +353,7 @@ let get_html ~logdir ~conf query pkgs =
     (show_diff_only_text, [show_diff_only]);
     (show_latest_only_text, [show_latest_only]);
     (sort_by_revdeps_text, [sort_by_revdeps]);
+    (packages_text, [packages]);
     (maintainers_text, [maintainers]);
     (logsearch_text, [logsearch; logsearch_comp]);
     ([], [submit_form]);

--- a/server/lib/html.mli
+++ b/server/lib/html.mli
@@ -6,6 +6,7 @@ type query = {
   show_diff_only : bool;
   show_latest_only : bool;
   sort_by_revdeps : bool;
+  packages : string * Re.re option;
   maintainers : string * Re.re option;
   logsearch : string * (Re.re * Intf.Compiler.t) option;
 }

--- a/server/lib/json.ml
+++ b/server/lib/json.ml
@@ -1,20 +1,26 @@
-let compiler_to_json compiler =
-  `String (Intf.Compiler.to_string compiler)
+let instance_to_json ~logdir ~pkgname instance =
+  let compiler = Intf.Compiler.to_string (Intf.Instance.compiler instance) in
+  let status = Intf.State.to_string (Intf.Instance.state instance) in
+  `Assoc (
+    [
+      ("compiler", `String compiler);
+      ("status", `String status);
+    ] @
+    match logdir with
+    | None -> []
+    | Some logdir ->
+        let logdir = Server_workdirs.get_logdir_name logdir in
+        (* NOTE: sync up with server/lib/server.ml *)
+        [("log", `String ("/log/"^logdir^"/"^compiler^"/"^status^"/"^pkgname))]
+  )
 
-let status_to_json state =
-  `String (Intf.State.to_string state)
-
-let instance_to_json instance =
+let pkg_to_json ~logdir pkg =
+  let pkgname = Intf.Pkg.full_name pkg in
+  let instances = Intf.Pkg.instances pkg in
   `Assoc [
-    ("compiler", compiler_to_json (Intf.Instance.compiler instance));
-    ("status", status_to_json (Intf.Instance.state instance));
+    ("name", `String pkgname);
+    ("statuses", `List (List.map (instance_to_json ~logdir ~pkgname) instances));
   ]
 
-let pkg_to_json pkg =
-  `Assoc [
-    ("name", `String (Intf.Pkg.full_name pkg));
-    ("statuses", `List (List.map instance_to_json (Intf.Pkg.instances pkg)));
-  ]
-
-let pkgs_to_json pkgs =
-  `List (List.map pkg_to_json pkgs)
+let pkgs_to_json ~logdir pkgs =
+  `List (List.map (pkg_to_json ~logdir) pkgs)

--- a/server/lib/json.mli
+++ b/server/lib/json.mli
@@ -1,1 +1,1 @@
-val pkgs_to_json : Intf.Pkg.t list -> Yojson.Safe.t
+val pkgs_to_json : logdir:Server_workdirs.logdir option -> Intf.Pkg.t list -> Yojson.Safe.t

--- a/server/lib/server.ml
+++ b/server/lib/server.ml
@@ -16,6 +16,20 @@ module Make (Backend : Backend_intf.S) = struct
     end [] |>
     List.rev
 
+  let comma_sep_glob_to_re str =
+    let glob_to_re glob =
+      let rec aux = function
+        | [] -> [Re.eol]
+        | [""] -> aux []
+        | [x] -> Re.str x :: aux []
+        | ""::xs -> Re.rep Re.any :: aux xs
+        | x::xs -> Re.str x :: Re.rep Re.any :: aux xs
+      in
+      Re.seq (Re.bol :: aux (String.split_on_char '*' glob))
+    in
+    Re.compile
+      (Re.alt (List.map glob_to_re (String.split_on_char ',' str)))
+
   let parse_raw_query logdir uri =
     let checkbox_default def = if List.is_empty (Uri.query uri) then def else false in
     let compilers = get_query_param_list uri "comp" in
@@ -29,6 +43,9 @@ module Make (Backend : Backend_intf.S) = struct
     let show_latest_only = if String.is_empty show_latest_only then checkbox_default true else bool_of_string show_latest_only in
     let sort_by_revdeps = option_to_string (Uri.get_query_param uri "sort-by-revdeps") in
     let sort_by_revdeps = if String.is_empty sort_by_revdeps then checkbox_default false else bool_of_string sort_by_revdeps in
+    let packages = option_to_string (Uri.get_query_param uri "packages") in
+    let packages = if String.is_empty packages then None else Some packages in
+    let packages = (option_to_string packages, Option.map comma_sep_glob_to_re packages) in
     let maintainers = option_to_string (Uri.get_query_param uri "maintainers") in
     let maintainers = if String.is_empty maintainers then None else Some maintainers in
     let maintainers = (option_to_string maintainers, Option.map (Re.Posix.compile_pat ~opts:[`ICase]) maintainers) in
@@ -62,6 +79,7 @@ module Make (Backend : Backend_intf.S) = struct
       Html.show_diff_only;
       Html.show_latest_only;
       Html.sort_by_revdeps;
+      Html.packages;
       Html.maintainers;
       Html.logsearch;
     }

--- a/server/lib/server.ml
+++ b/server/lib/server.ml
@@ -166,9 +166,15 @@ module Make (Backend : Backend_intf.S) = struct
                 let* html = Cache.get_html_diff ~conf ~old_logdir ~new_logdir Backend.cache in
                 serv_text ~content_type:"text/html" html))
     | ["log"; logdir; comp; state; pkg] ->
+        (* NOTE: sync up with server/lib/json.ml *)
         get_log ~logdir ~comp ~state ~pkg
-    | ["api"; "v1"; "latest"; "packages"] ->
-        let* json = Cache.get_json_latest_packages Backend.cache in
+    | ["api"; ("v1" | "v2") as api_version; "latest"; "packages"] ->
+        let api_version = match api_version with
+          | "v1" -> `V1
+          | "v2" -> `V2
+          | _ -> assert false
+        in
+        let* json = Cache.get_json_latest_packages api_version Backend.cache in
         serv_text ~content_type:"application/json" json
     | ["metrics"] ->
         let* data = Prometheus.CollectorRegistry.(collect default) in


### PR DESCRIPTION
opam-repository maintainers (cc @raphael-proust) requested some features from check.ci.ocaml.org to allow to simplify their work.
This PR should be read commit by commit as it cherry-picks individual commits from [opam-health-check-ng](https://github.com/kit-ty-kate/opam-health-check-ng).

Work kindly financed by the ocaml software foundation.